### PR TITLE
Allows arbitrary objects to be passed to templates as data

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,13 @@ module.exports = function(grunt) {
            dest: 'tmp/hello_yaml.html'}
         ]
       },
+      arbitrary_data: {
+        files: [
+          {data: { greeting: "Hello", target: "world" },
+           template: 'test/fixtures/templates/hello_world.html.mustache',
+           dest: 'tmp/hello_arbitrary.html'}
+        ]
+      },
       partials_directory: {
         options: {
           directory: 'test/fixtures/partials/'

--- a/tasks/mustache_render.js
+++ b/tasks/mustache_render.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
     } else if (/\.yaml/i.test(dataPath)) {
       return grunt.file.readYAML(dataPath);
     } else {
-      grunt.log.error("Data file must be JSON or YAML. Given: " + dataPath);
+      return dataPath;
     }
   },
 

--- a/test/mustache_render_test.js
+++ b/test/mustache_render_test.js
@@ -48,6 +48,17 @@ exports.mustache_render = {
     test.done();
   },
 
+  arbitrary_data: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/hello_arbitrary.html');
+    var expected = grunt.file.read('test/expected/hello_world.html');
+
+    test.equal(actual, expected, 'should render when given arbitrary data.');
+
+    test.done();
+  },
+
   partials_directory: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
This attempts to take care of #4.

I opted to remove the notice pertaining to acceptable content types, mostly because I'm not sure what an acceptable guard would look like (my knowledge of sniffing JavaScript types is lacking). A more legitimate reason might be that mustache can handle arbitrary types passed as data, so there's no need to filter its inputs.
