### PR TITLE
Added escape option which if set to false disables escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Default value: `false`
 
 Clears the mustache cache before running the target. Mustache will cache partials by name when running multiple tasks, so this option is usefull if `options.extension`, `options.directory`, or `options.prefix` have been changed between tasks.
 
+### options.escape
+Type: `Boolean`  
+Default value: `true`
+
+If set to `false` it disables default HTML escaping. That means that `{{var}}` will not be escaped. This is usefull for templating files that are not HTML.
+
 ### Usage Examples
 
 For this Grunt config:

--- a/tasks/mustache_render.js
+++ b/tasks/mustache_render.js
@@ -16,7 +16,8 @@ module.exports = function gruntTask(grunt) {
     directory : "",
     extension : ".mustache",
     prefix : "",
-    clear_cache : false
+    clear_cache : false,
+    escape: true
   };
 
   /**
@@ -95,6 +96,10 @@ module.exports = function gruntTask(grunt) {
       var renderer = new GMR(this.options);
 
       if (renderer.options.clear_cache) { mustache.clearCache(); }
+
+      if (!renderer.options.escape) { 
+        mustache.escape = function (text) { return text; }
+      }
 
       this.files.forEach(function renderFile(fileData) {
         renderer.render(fileData.data, fileData.template, fileData.dest);


### PR DESCRIPTION
Mustache escapes {{var}} by default. With the options.escape option, this can be turned off in the Grunt Task.

I applied the solution described here: https://github.com/janl/mustache.js/issues/244
