### PR TITLE
Output task progress to console

### DIFF
--- a/tasks/mustache_render.js
+++ b/tasks/mustache_render.js
@@ -107,8 +107,15 @@ module.exports = function gruntTask(grunt) {
 
       this.files.forEach(function renderFile(fileData) {
         renderer.render(fileData.data, fileData.template, fileData.dest);
-        grunt.log.writeln("Wrote " + fileData.dest.cyan + " using " +
-          (Object.keys(fileData.data).length + " variables").green);
+
+        grunt.log.writeln(
+          "Wrote " + fileData.dest.cyan + " using " +
+          (
+            typeof fileData.data === 'object' ?
+            Object.keys(fileData.data).length + " variables" :
+            "external data"
+          ).green
+        );
       });
   });
 };


### PR DESCRIPTION
Most Grunt plugins write output to the console as files are processed, but `mustache_render` is silent. This made it harder to work with as I was fine-tuning my build process so that `watch` tasks only process the specific files that had changed.

I added a bit of logging to mine to help me out, and maybe others would find it helpful too.
