### PR TITLE
Allow JS as datafile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,13 @@ module.exports = function(grunt) {
            dest: 'tmp/hello_arbitrary.html'}
         ]
       },
+      js_data: {
+         files: [
+           {data: 'test/fixtures/objects/hello_world.js',
+            template: 'test/fixtures/templates/hello_world.html.mustache',
+            dest: 'tmp/hello_js.html'}
+         ]
+      },
       partials_directory: {
         options: {
           directory: 'test/fixtures/partials/'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/5thWall/mustache-render.png?branch=master)](https://travis-ci.org/5thWall/mustache-render)
 [![NPM version](https://badge.fury.io/js/grunt-mustache-render.png)](http://badge.fury.io/js/grunt-mustache-render)
 
-This is a grunt plugin to render [mustache](http://mustache.github.io/) templates. It takes data in `JSON`, `YAML`, or `POJO` (Plain Ol' JavaScript Object) format. It allows you to specify a folder for partials, instead of needing to list them individually.
+This is a grunt plugin to render [mustache](http://mustache.github.io/) templates. It takes data in `JSON`, `YAML`, `JS` or `POJO` (Plain Ol' JavaScript Object) format. It allows you to specify a folder for partials, instead of needing to list them individually.
 
 ## Getting Started
 This plugin requires Grunt `~0.4.1`
@@ -37,7 +37,7 @@ grunt.initConfig({
       },
       files : [
         {
-          data: // Path or URL to JSON or YAML file, or POJO
+          data: // Path or URL to JS, JSON or YAML file, or POJO
           template: // Path or URL to template file
           dest: // Path to output destination here
         }
@@ -46,7 +46,7 @@ grunt.initConfig({
   },
 })
 ```
-**Note:** The `files` parameter _must_ be an array, and _must_ conform to the format specified above. Each object in the file array represents _one_ rendered template. Data files can be in either `JSON` or `YAML` format or as a `POJO` (Plain Ol' JavaScript Object).
+**Note:** The `files` parameter _must_ be an array, and _must_ conform to the format specified above. Each object in the file array represents _one_ rendered template. Data files can be in either `JSON`, `YAML` format, or as either an external `JS` file via `module.exports` or a `POJO` (Plain Ol' JavaScript Object).
 
 #### Building Long File Lists
 
@@ -107,7 +107,7 @@ files: {
 files: [
   {expand: true,
    src: 'template/to/read-*.mustache',
-   data: 'common-data.json',
+   data: 'common-data.js',
    dest: 'dest/directory/'}
 ]
 ```

--- a/tasks/mustache_render.js
+++ b/tasks/mustache_render.js
@@ -156,6 +156,8 @@ module.exports = function gruntTask(grunt) {
       return grunt.file.readJSON(dataPath);
     } else if (/\.ya?ml/i.test(dataPath)) {
       return grunt.file.readYAML(dataPath);
+    } else if (/\.js/i.test(dataPath)) {
+      return require(path.resolve('.', dataPath));
     }
 
     throw new Error("Data file must be JSON or YAML. Given: " + dataPath);

--- a/test/fixtures/objects/hello_world.js
+++ b/test/fixtures/objects/hello_world.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "greeting": "Hello",
+  "target": function() {
+     return "world";
+  }
+};

--- a/test/mustache_render_test.js
+++ b/test/mustache_render_test.js
@@ -100,6 +100,17 @@ exports.mustache_render = {
     test.done();
   },
 
+  js_data: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/hello_js.html');
+    var expected = grunt.file.read('test/expected/hello_world.html');
+
+    test.equal(actual, expected, 'should render when given arbitrary data.');
+
+    test.done();
+  },
+
   partials_directory: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
- `data: ‘data.js’` now works by `require`ing the JS file
- Test case, including one computed property
- Updated documentation
