### PR TITLE
glob expansion for partials search

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,6 +193,30 @@ module.exports = function(grunt) {
            dest: 'tmp/hello_partial_function.html'}
         ]
       },
+      partials_glob_df: { // glob expansion partial search (like partials_dfprefixes)
+          options: {
+            directory: 'test/fixtures/partials/',
+            glob: 'sub-$1/pre_$2.mustache',
+            clear_cache: true
+          },
+          files: [
+            {data: 'test/fixtures/objects/hello_world.json',
+             template: 'test/fixtures/templates/hello_partial_dir.mustache',
+             dest: 'tmp/hello_partial_globdf.html'}
+          ]
+      },
+      partials_glob: {
+          options: {
+            directory: 'test/fixtures/partials/',
+            glob: '{sub-$1,.}/$2.!(ms)',
+            clear_cache: true
+          },
+          files: [
+            {data: 'test/fixtures/objects/hello_world.json',
+             template: 'test/fixtures/templates/hello_partial_glob.mustache',
+             dest: 'tmp/hello_partial_glob.html'}
+          ]
+      },
       batch_single_template_multiple_json_via_map: {
         options: {
           template: 'test/fixtures/templates/hello_world.html.mustache'

--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ which prepended onto the partial reference, regardless of whether it included
 a directory or not. This option is still supported for backward compatibility
 and maintains the same behavior.
 
+#### options.glob
+Type: `String`  
+Default value: `""`
+
+A glob pattern to use to search for partials. If this option is set, `options.prefix_file`, `options.prefix_dir`,
+`options.prefix` and `options.extension` will be ignored. The glob pattern will be expanded using 
+[`grunt.file.expand`](http://gruntjs.com/api/grunt.file#grunt.file.expand) and the first file found will be used.
+If more than one file is found, a warning will be printed.
+
+You can use this variables in the pattern:
+ * `$0` The whole partial name
+ * `$1` The partial name's directory part
+ * `$2` The partial name's basename part
+
+Examples:
+ * `prefix_dir$1/prefix_file$2` does the same as using `options.prefix_file` and `options.prefix_dir`
+ * `$0.*` allows any extension
+ * `{images/$0.svg,partials/$0.mustache}` seaches for a partial either as `name.svg` in the `image` folder or as `name.mustache` in the `partials` folder.
+
 #### options.clear_cache
 Type: `Boolean`  
 Default value: `false`

--- a/test/expected/hello_glob.html
+++ b/test/expected/hello_glob.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>A partial</title>
+</head>
+<body>
+  <h1>Hello mustache with glob patterns!</h1>
+Hello glob pattern!
+  You can use any file extension :)
+
+</body>
+</html>

--- a/test/fixtures/partials/sub-b/another.fancy
+++ b/test/fixtures/partials/sub-b/another.fancy
@@ -1,0 +1,1 @@
+use any file extension :)

--- a/test/fixtures/partials/sub-b/hello.ext
+++ b/test/fixtures/partials/sub-b/hello.ext
@@ -1,0 +1,1 @@
+Hello glob pattern!

--- a/test/fixtures/templates/hello_partial_glob.mustache
+++ b/test/fixtures/templates/hello_partial_glob.mustache
@@ -1,0 +1,7 @@
+{{> head}}
+<body>
+  <h1>Hello mustache with glob patterns!</h1>
+  {{> b/hello}} 
+  You can {{> b/another}}
+</body>
+</html>

--- a/test/mustache_render_test.js
+++ b/test/mustache_render_test.js
@@ -203,6 +203,28 @@ exports.mustache_render = {
     test.done();
   },
 
+  partials_glob_df: function(test) {  // glob expansion partial search (like dfprefixes)
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/hello_partial_globdf.html');
+    var expected = grunt.file.read('test/expected/hello_dfprefixes.html');
+    test.equal(actual, expected, 'should find partials w/ glob ' +
+      '"sub-$1/pre_$2.mustache".');
+
+    test.done();
+  },
+
+  partials_glob: function(test) {  // glob expansion partial search
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/hello_partial_glob.html');
+    var expected = grunt.file.read('test/expected/hello_glob.html');
+    test.equal(actual, expected, 'should find partials w/ glob ' +
+      '"?(+sub-$1)/$2.*".');
+
+    test.done();
+  },
+
   batch_single_template_multiple_json_via_map: function(test) {
     test.expect(3);
 


### PR DESCRIPTION
For my own use, I found it convenient to be able to use glob patterns to specify where to search for partials. As I thought others may like that too, I documented and tested the feature to offer it through this pull request.

This pull request adds `options.glob` to specify a glob pattern (that will be interpreted by minimatch) to search for partial files. 
In the glob pattern, the user may use these variables:
 * `$0` for the whole partial name.
 * `$1` for the directory part
 * `$2` for the basename part

The pattern will by expanded and the first match will be used. If more than one file was matched, a warning will be printed.

This allows a rather intuitive (from my point of view) way to specify more complex search criteria for partial files.
For instance, I don't want to implement my own function (that must also read the files) just to allow any files extension for partials. With this feature, I can simply specify: `glob: '$0.*'`
Or, even for more complex use cases, I still like writing patterns more. If I have two folders for partials, I can specify: `{dir1/$0.ext1,dir2/$0.ext2}`
